### PR TITLE
rename find_and_replace to :compile

### DIFF
--- a/lib/marky_markdown.rb
+++ b/lib/marky_markdown.rb
@@ -4,7 +4,7 @@ module MarkyMarkdown
   class Transformer
     def self.transform(str)
       variable_hash = self.identify_variables(str)
-      self.find_and_replace({variables: variable_hash, body: str})
+      self.compile({variables: variable_hash, body: str})
     end
 
     def self.identify_variables(str)
@@ -17,7 +17,7 @@ module MarkyMarkdown
       Hash[key_value_array.map { |key, value| [key, value]  }]
     end
 
-    def self.find_and_replace(input)
+    def self.compile(input)
       input[:variables].each do |k, v|
         next if v.nil?
 

--- a/test/marky_markdown_test.rb
+++ b/test/marky_markdown_test.rb
@@ -23,9 +23,9 @@ class MarkyMarkdownTest < Minitest::Test
     assert_instance_of Hash, variables, "Variable hash was not created"
   end
 
-  def test_find_and_replace
+  def test_compile
     variables = MarkyMarkdown::Transformer.identify_variables(@test_case)
-    transformation = MarkyMarkdown::Transformer.find_and_replace({variables: variables, body: @test_case})
+    transformation = MarkyMarkdown::Transformer.compile({variables: variables, body: @test_case})
     assert transformation.include?("Say hi to your mother")
     assert_instance_of String, transformation, "Transformed string was not created"
   end


### PR DESCRIPTION
This API change is to simplify the method naming and work towards #8 